### PR TITLE
Add support for var dumper

### DIFF
--- a/src/Junker/DebugBar/Bridge/SmartyCollector.php
+++ b/src/Junker/DebugBar/Bridge/SmartyCollector.php
@@ -11,6 +11,36 @@ class SmartyCollector extends DataCollector implements Renderable
 {
 	protected $smarty;
 
+	/**
+	 * @var bool
+	 */
+	protected $useHtmlVarDumper = false;
+
+	/**
+	 * Sets a flag indicating whether the Symfony HtmlDumper will be used to dump variables for
+	 * rich variable rendering.
+	 *
+	 * @param bool $value
+	 * @return $this
+	 */
+	public function useHtmlVarDumper($value = true)
+	{
+		$this->useHtmlVarDumper = $value;
+
+		return $this;
+	}
+
+	/**
+	 * Indicates whether the Symfony HtmlDumper will be used to dump variables for rich variable
+	 * rendering.
+	 *
+	 * @return mixed
+	 */
+	public function isHtmlVarDumperUsed()
+	{
+		return $this->useHtmlVarDumper;
+	}
+
 	public function __construct($smarty)
 	{
 		$this->smarty = $smarty;
@@ -21,7 +51,11 @@ class SmartyCollector extends DataCollector implements Renderable
 		$vars = $this->smarty->getTemplateVars();
 
 		foreach ($vars as $idx => $var) {
-            $data[$idx] = $this->getDataFormatter()->formatVar($var);
+			if ($this->isHtmlVarDumperUsed()) {
+				$data[$idx] = $this->getVarDumper()->renderVar($var);
+			} else {
+				$data[$idx] = $this->getDataFormatter()->formatVar($var);
+			}
         }
 
         return $data;
@@ -34,10 +68,13 @@ class SmartyCollector extends DataCollector implements Renderable
 
     public function getWidgets()
     {
+        $widget = $this->isHtmlVarDumperUsed()
+            ? "PhpDebugBar.Widgets.HtmlVariableListWidget"
+            : "PhpDebugBar.Widgets.VariableListWidget";
         return array(
             "smarty" => array(
                 "icon" => "tags",
-                "widget" => "PhpDebugBar.Widgets.VariableListWidget",
+                "widget" => $widget,
                 "map" => "smarty",
                 "default" => "{}"
             )


### PR DESCRIPTION
This PR adds a new `useHtmlVarDumper()` method that makes the collector use the var dumper to render Smarty variables.
This means the variables can then be inspected more easily.